### PR TITLE
[BDB-3] Handle ApplyConfigurationsFromAssembly in BaseDbContext

### DIFF
--- a/Infrastructures/BuildingBlock.Infrastructure.EntityFrameworkCore/BaseDbContext.cs
+++ b/Infrastructures/BuildingBlock.Infrastructure.EntityFrameworkCore/BaseDbContext.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BuildingBlock.Infrastructure.EntityFrameworkCore;
 
-public class BaseDbContext : DbContext
+public abstract class BaseDbContext : DbContext
 {
     private readonly ICurrentUser _currentUser;
     private readonly IMediator _mediator;
@@ -18,6 +18,8 @@ public class BaseDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
+        builder.ApplyConfigurationsFromAssembly(GetType().Assembly);
+
         base.OnModelCreating(builder);
     }
 


### PR DESCRIPTION
Currently, we have to call ApplyConfigurationsFromAssembly manually in the child class derived from BaseDbContext

=> Handle ApplyConfigurationsFromAssembly in BaseDbContext, so we doesn’t have to override OnModelCreating method

https://superbad-store.atlassian.net/browse/BDB-3